### PR TITLE
Fix: autoload only if need to

### DIFF
--- a/bin/migrations.php
+++ b/bin/migrations.php
@@ -1,7 +1,9 @@
 #!/usr/bin/env php
 <?php
 // Debugging: SET XDEBUG_CONFIG=idekey=netbeans-xdebug
-require __DIR__ . '/../vendor/autoload.php';
+if (!(class_exists('Symfony\\Component\\Console\\Application') && class_exists('Odan\\Migration\\Command\\GenerateCommand'))) {
+    require __DIR__ . '/../vendor/autoload.php';
+}
 
 use Odan\Migration\Command\GenerateCommand;
 use Symfony\Component\Console\Application;


### PR DESCRIPTION
We do not need composer's autoload when package is used as dependency and autoloader has already worked. So we check if both namespaces are found and if they are - we skip autoloader inclusion.